### PR TITLE
ci: bump actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     name: TypeScript
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm
@@ -24,8 +24,8 @@ jobs:
     name: Python
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - run: pip install -r python/requirements.txt


### PR DESCRIPTION
checkout@v4 / setup-node@v4 / setup-python@v5 run on the Node 20 action runtime, which GitHub force-migrates to Node 24 on June 16, 2026 and removes from runners on September 16, 2026 (see annotations on recent CI runs). This bumps all three to their current majors (checkout@v6, setup-node@v6, setup-python@v6), which target Node 24. No workflow inputs changed.